### PR TITLE
Makes target `all` a phony target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ LD = ld
 targets = helloworld.img guess.img
 
 all: $(targets)
+.PHONY: all
 
 %.img: %.o
 	$(LD) --omagic --oformat=binary --Ttext=0x7C00 -o $@ $<


### PR DESCRIPTION
As target `all` does not point to any file it's better to be a phony target.